### PR TITLE
Change the executable to allow different paths

### DIFF
--- a/sourcetree-merge-request-opener
+++ b/sourcetree-merge-request-opener
@@ -1,4 +1,4 @@
-#!/usr/local/bin/php
+#!/usr/bin/env php
 <?php
 
 foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {


### PR DESCRIPTION
For me PHP is installed in `/usr/bin/php` not `/usr/local/bin/php`
* https://thomashunter.name/blog/creating-self-executable-php-scripts/